### PR TITLE
Add banklink configuration key SEND_REF

### DIFF
--- a/tests/test_generic.py
+++ b/tests/test_generic.py
@@ -39,6 +39,7 @@ def get_banklink_config(bank_name=None, printable_name=None):
             'TYPE': 'banklink',
             'IMAGE_PATH': 'swedbank.png',
             'ORDER': 1,
+            'SEND_REF': True,
         },
         'seb': {
             'PRINTABLE_NAME': 'SEB',
@@ -51,6 +52,7 @@ def get_banklink_config(bank_name=None, printable_name=None):
             'TYPE': 'banklink',
             'IMAGE_PATH': 'seb.png',
             'ORDER': 2,
+            'SEND_REF': False,
         },
         'lhv': {
             'PRINTABLE_NAME': 'LHV',
@@ -157,6 +159,10 @@ def test_getters(settings):
     assert th_settings.get_client_id("swedbank") == conf["swedbank"]["CLIENT_ID"]
     assert th_settings.get_request_url("swedbank") == conf["swedbank"]["REQUEST_URL"]
     assert th_settings.get_link_type("swedbank") == conf["swedbank"]["TYPE"]
+
+    assert th_settings.get_send_ref("swedbank") == conf["swedbank"]["SEND_REF"]
+    assert th_settings.get_send_ref("seb") == conf["seb"]["SEND_REF"]
+    assert th_settings.get_send_ref("danske") is True
 
     the_list = th_settings.get_bank_choices()
     assert isinstance(the_list, list)

--- a/tests/test_payment.py
+++ b/tests/test_payment.py
@@ -15,16 +15,19 @@ from tests.utils import select_radio, click, IPIZZA_BANKS, ready, set_input_text
 
 
 @pytest.mark.parametrize("bank_name", IPIZZA_BANKS)
+@pytest.mark.parametrize("send_ref", [True, False])
 @pytest.mark.django_db
 @pytest.mark.timeout(TIMEOUT)
-def test_payment_flow(bank_name, live_server, selenium):
+def test_payment_flow(bank_name, send_ref, live_server, selenium):
     from shop.models import Order
     from thorbanks.models import Transaction
+
+    assert bank_name in IPIZZA_BANKS
 
     if IS_TRAVIS:
         time.sleep(1 + random.uniform(0.5, 2.3))  # Give server time to start up
 
-    pay_url = '%s%s' % (live_server.url, reverse('payment'))
+    pay_url = '%s%s?send_ref=%d' % (live_server.url, reverse('payment'), 1 if send_ref else 0)
 
     # Get the order page
     selenium.get(pay_url)

--- a/thorbanks/forms.py
+++ b/thorbanks/forms.py
@@ -13,6 +13,7 @@ from django.utils.safestring import mark_safe
 from django.utils.translation import ugettext_lazy as _
 
 from thorbanks import settings
+from thorbanks.settings import get_send_ref
 from thorbanks.utils import create_signature, nordea_generate_mac
 from thorbanks.signals import transaction_started
 from thorbanks.utils import calculate_731_checksum
@@ -237,7 +238,7 @@ class PaymentRequest(PaymentRequestBase):
     VK_STAMP = forms.CharField(widget=forms.HiddenInput())
     VK_AMOUNT = forms.CharField(widget=forms.HiddenInput())
     VK_CURR = forms.CharField(widget=forms.HiddenInput())
-    VK_REF = forms.CharField(widget=forms.HiddenInput())
+    VK_REF = forms.CharField(widget=forms.HiddenInput(), required=False)
     VK_MSG = forms.CharField(widget=forms.HiddenInput())
     VK_RETURN = forms.CharField(widget=forms.HiddenInput())
     VK_CANCEL = forms.CharField(widget=forms.HiddenInput())
@@ -262,7 +263,7 @@ class PaymentRequest(PaymentRequestBase):
             'VK_SND_ID': settings.get_client_id(transaction.bank_name),
 
             'VK_STAMP': transaction.pk,
-            'VK_REF': calculate_731_checksum(transaction.pk),
+            'VK_REF': calculate_731_checksum(transaction.pk) if get_send_ref(transaction.bank_name) else '',
 
             'VK_AMOUNT': transaction.amount,
             'VK_CURR': transaction.currency,

--- a/thorbanks/settings.py
+++ b/thorbanks/settings.py
@@ -111,6 +111,10 @@ def get_link_protocol(the_bank):
     return LINKS[the_bank].get('PROTOCOL', 'ipizza')
 
 
+def get_send_ref(the_bank):
+    return LINKS[the_bank].get('SEND_REF', True)
+
+
 def get_bank_choices():
     """ Returns list of (bank_name, pretty_name, image_path, order) tuples.
     Useful in forms


### PR DESCRIPTION
This boolean setting can be used to disable automatic reference
number generation for payments (it defaults to True), e.g.:

```
BANKLINKS = {
    'seb': {
        'SEND_REF': False,  # Disable ref numbers for SEB bank payments
    },
}
```

---

based on #9 by @wanaryytel, however it's implemented in a way that covers more use-cases. This also includes tests for send_ref
