### PR TITLE
Banklink specification 1.2 support. 

### DIFF
--- a/tests/test_generic.py
+++ b/tests/test_generic.py
@@ -44,7 +44,8 @@ def get_banklink_config(bank_name=None, printable_name=None):
             "IMAGE_PATH": "swedbank.png",
             "ORDER": 1,
             "SEND_REF": True,
-            "HASH_ALGORITHM": "sha1",
+            "SIGN_HASH_ALGORITHM": "sha1",
+            "VERIFY_HASH_ALGORITHM": "sha1",
         },
         "seb": {
             "PRINTABLE_NAME": "SEB",
@@ -58,7 +59,8 @@ def get_banklink_config(bank_name=None, printable_name=None):
             "IMAGE_PATH": "seb.png",
             "ORDER": 2,
             "SEND_REF": False,
-            "HASH_ALGORITHM": "sha256",
+            "SIGN_HASH_ALGORITHM": "sha512",
+            "VERIFY_HASH_ALGORITHM": "sha512",
             "VK_VERSION": "009",
         },
         "lhv": {
@@ -82,6 +84,7 @@ def get_banklink_config(bank_name=None, printable_name=None):
             "TYPE": "banklink",
             "IMAGE_PATH": "danske.png",
             "ORDER": 4,
+            "VERIFY_HASH_ALGORITHM": "sha512",
         },
     }
 
@@ -156,8 +159,21 @@ def test_getters(settings):
     assert th_settings.get_client_id("swedbank") == conf["swedbank"]["CLIENT_ID"]
     assert th_settings.get_request_url("swedbank") == conf["swedbank"]["REQUEST_URL"]
     assert th_settings.get_link_type("swedbank") == conf["swedbank"]["TYPE"]
+
     assert (
-        th_settings.get_hash_algorithm("swedbank") == conf["swedbank"]["HASH_ALGORITHM"]
+        th_settings.get_verify_hash_algorithm("swedbank")
+        == conf["swedbank"]["VERIFY_HASH_ALGORITHM"]
+    )
+    assert (
+        th_settings.get_sign_hash_algorithm("swedbank")
+        == conf["swedbank"]["SIGN_HASH_ALGORITHM"]
+    )
+    assert (
+        th_settings.get_verify_hash_algorithm("seb")
+        == conf["seb"]["VERIFY_HASH_ALGORITHM"]
+    )
+    assert (
+        th_settings.get_sign_hash_algorithm("seb") == conf["seb"]["SIGN_HASH_ALGORITHM"]
     )
 
     assert th_settings.get_send_ref("swedbank") == conf["swedbank"]["SEND_REF"]

--- a/tests/test_generic.py
+++ b/tests/test_generic.py
@@ -59,6 +59,7 @@ def get_banklink_config(bank_name=None, printable_name=None):
             "ORDER": 2,
             "SEND_REF": False,
             "HASH_ALGORITHM": "sha256",
+            "VK_VERSION": "009",
         },
         "lhv": {
             "PRINTABLE_NAME": "LHV",
@@ -162,6 +163,8 @@ def test_getters(settings):
     assert th_settings.get_send_ref("swedbank") == conf["swedbank"]["SEND_REF"]
     assert th_settings.get_send_ref("seb") == conf["seb"]["SEND_REF"]
     assert th_settings.get_send_ref("danske") is True
+
+    assert th_settings.get_version("seb") == conf["seb"]["VK_VERSION"]
 
     the_list = th_settings.get_bank_choices()
     assert isinstance(the_list, list)

--- a/thorbanks/forms.py
+++ b/thorbanks/forms.py
@@ -235,7 +235,7 @@ class PaymentRequest(PaymentRequestBase):
         self.data["VK_MAC"] = create_signature(
             self.cleaned_data,
             self.transaction.bank_name,
-            settings.get_hash_algorithm(self.transaction.bank_name),
+            settings.get_sign_hash_algorithm(self.transaction.bank_name),
         )
 
 

--- a/thorbanks/forms.py
+++ b/thorbanks/forms.py
@@ -93,7 +93,7 @@ class IPizzaAuthRequest(AuthRequestBase):
     def prepare(self, bank_name, redirect_to, response_url, *args, **kwargs):
         initial = {
             "VK_SERVICE": "4012",
-            "VK_VERSION": "008",
+            "VK_VERSION": settings.get_version(bank_name),
             "VK_SND_ID": settings.get_client_id(bank_name),
             "VK_REC_ID": settings.get_bank_id(bank_name),
             "VK_NONCE": self.auth.pk,
@@ -215,7 +215,7 @@ class PaymentRequest(PaymentRequestBase):
 
         return {
             "VK_SERVICE": "1012",
-            "VK_VERSION": "008",
+            "VK_VERSION": settings.get_version(transaction.bank_name),
             "VK_ENCODING": self.get_encoding(),
             "VK_DATETIME": transaction.created.strftime("%Y-%m-%dT%H:%M:%S%z"),
             "VK_RETURN": url,

--- a/thorbanks/settings.py
+++ b/thorbanks/settings.py
@@ -24,7 +24,8 @@ def parse_banklinks(config=None):
                     "SEND_REF": True,
                     "PUBLIC_KEY": None,
                     "PRIVATE_KEY": None,
-                    "HASH_ALGORITHM": "sha1",
+                    "SIGN_HASH_ALGORITHM": "sha1",
+                    "VERIFY_HASH_ALGORITHM": "sha1",
                     "VK_VERSION": "008",
                 }
 
@@ -127,8 +128,12 @@ def get_send_ref(the_bank):
     return get_links()[the_bank]["SEND_REF"]
 
 
-def get_hash_algorithm(the_bank):
-    return get_links()[the_bank]["HASH_ALGORITHM"]
+def get_sign_hash_algorithm(the_bank):
+    return get_links()[the_bank]["SIGN_HASH_ALGORITHM"]
+
+
+def get_verify_hash_algorithm(the_bank):
+    return get_links()[the_bank]["VERIFY_HASH_ALGORITHM"]
 
 
 def get_bank_choices():

--- a/thorbanks/settings.py
+++ b/thorbanks/settings.py
@@ -25,6 +25,7 @@ def parse_banklinks(config=None):
                     "PUBLIC_KEY": None,
                     "PRIVATE_KEY": None,
                     "HASH_ALGORITHM": "sha1",
+                    "VK_VERSION": "008",
                 }
 
                 final_data.update(bank_data)
@@ -104,6 +105,10 @@ def get_client_id(the_bank):
 
 def get_bank_id(the_bank):
     return get_links()[the_bank]["BANK_ID"]
+
+
+def get_version(the_bank):
+    return get_links()[the_bank]["VK_VERSION"]
 
 
 def get_request_url(the_bank):

--- a/thorbanks/utils.py
+++ b/thorbanks/utils.py
@@ -180,7 +180,7 @@ def verify_signature(request, bank_name, signature, auth=False, response=False):
 
     digest = request_digest(request, bank_name, auth=auth, response=response)
 
-    hash_algorithm = settings.get_hash_algorithm(bank_name)
+    hash_algorithm = settings.get_verify_hash_algorithm(bank_name)
     hasher = _get_hasher(hash_algorithm, bank_name)
 
     try:

--- a/thorbanks/utils.py
+++ b/thorbanks/utils.py
@@ -1,3 +1,4 @@
+import logging
 from base64 import b64decode, b64encode
 from functools import reduce
 
@@ -67,6 +68,15 @@ HASH_ALGORITHMS = {
     "sha512": hashes.SHA512(),  # Should be used for banklink 1.2 specification (009)
     "sha256": hashes.SHA256(),  # Potentially unused, was supported for SEB with their own updated 1.1 specification
 }
+
+
+def _get_hasher(hash_algorithm, bank_name):
+    hasher = HASH_ALGORITHMS.get(hash_algorithm)
+    if hasher is None:
+        raise ValueError(
+            "Invalid hash algorithm %s used for %s" % (hash_algorithm, bank_name)
+        )
+    return hasher
 
 
 def get_ordered_request(request, auth=False, response=False):
@@ -153,12 +163,7 @@ def create_signature(request, bank_name, hash_algorithm="sha1", auth=False):
 
     private_key = get_pkey(bank_name)
 
-    hasher = HASH_ALGORITHMS.get(hash_algorithm)
-    if hasher is None:
-        raise ValueError(
-            "Invalid hash algorithm %s used for %s" % (hash_algorithm, bank_name)
-        )
-
+    hasher = _get_hasher(hash_algorithm, bank_name)
     signature = private_key.sign(digest, padding.PKCS1v15(), hasher)
 
     return force_str(b64encode(signature))
@@ -175,16 +180,41 @@ def verify_signature(request, bank_name, signature, auth=False, response=False):
 
     digest = request_digest(request, bank_name, auth=auth, response=response)
 
-    for hash_algorithm in HASH_ALGORITHMS.values():
-        try:
-            public_key.verify(
-                b64decode(signature), digest, padding.PKCS1v15(), hash_algorithm
-            )
-            return True
+    hash_algorithm = settings.get_hash_algorithm(bank_name)
+    hasher = _get_hasher(hash_algorithm, bank_name)
 
-        except InvalidSignature:
-            pass
-    return False
+    try:
+        public_key.verify(b64decode(signature), digest, padding.PKCS1v15(), hasher)
+        return True
+    except InvalidSignature:
+        # Verification with the configured hash algorithm failed. We will try to verify
+        # with the other hash algorithms as a fallback in case the bank has switched
+        # to a new hash algorithm.
+        for hash_algorithm, hasher in HASH_ALGORITHMS.items():
+            try:
+                public_key.verify(
+                    b64decode(signature), digest, padding.PKCS1v15(), hasher
+                )
+                logging.warning(
+                    "%s banklink is using %s hash algorithm, "
+                    "but the banklink configuration is using %s.",
+                    bank_name,
+                    hash_algorithm,
+                    settings.get_hash_algorithm(bank_name),
+                )
+                return True
+            except InvalidSignature:
+                pass
+
+        if not auth:
+            # The client might have paid, but we don't accept the banklink response.
+            # Need to check if the payment was successful and contact the client!
+            logging.critical(
+                "Signature verification for the successful %s banklink callback has "
+                "failed. Immediate action required to confirm the payment's status.",
+                bank_name,
+            )
+        return False
 
 
 def weight_generator():


### PR DESCRIPTION
Add SHA-512 hashing option as well as dynamic VK_VERSION option to support banklink specification 1.2.

Spec 1.1:
[Pangalingi_tehniline_spetsifikatsioon_1.1.pdf](https://github.com/thorgate/django-thorbanks/files/12832993/Pangalingi_tehniline_spetsifikatsioon_1.1.pdf)

Spec 1.2:
[Pangalingi_tehniline_spetsifikatsioon_1.2.pdf](https://github.com/thorgate/django-thorbanks/files/12833000/Pangalingi_tehniline_spetsifikatsioon_1.2.pdf)

I did put those through a diff tool as well. Not many changes, all of them limited to
1. Only UTF-8 encoding supported in the newer
2. New VK_VERSION VALUE (009 instead of 008)
3. Biometry support for auth